### PR TITLE
Upload file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ dist:
 
 .PHONY: glide
 glide:
-ifndef GLIDE
+ifeq ($(shell command -v glide 2> /dev/null),)
 	curl https://glide.sh/get | sh
 endif
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Generate [S3 object pre-signed URL](http://docs.aws.amazon.com/AmazonS3/latest/d
   + [Precompiled binary](#precompiled-binary)
   + [From source](#from-source)
 * [Usage](#usage)
+  + [Upload file together](#upload-file-together)
   + [Options](#options)
 * [Development](#development)
 * [License](#license)

--- a/README.md
+++ b/README.md
@@ -44,23 +44,27 @@ export AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 export AWS_REGION=xx-yyyy-0
 ```
 
-Put object into S3 bucket using Management Console or awscli.
-
-```bash
-$ aws s3 cp foo_file s3://BUCKET/KEY
-```
-
 Just type the command below and get Pre-signed URL on the screen.
 
 ```bash
 # https:// URL
-$ s3url https://s3-region.amazonaws.com/BUCKET/KEY [-d DURATION] [--profile PROFILE]
+$ s3url https://s3-region.amazonaws.com/BUCKET/KEY [-d DURATION] [--profile PROFILE] [--upload UPLOAD]
 
 # s3:// URL
-$ s3url s3://BUCKET/KEY [-d DURATION] [--profile PROFILE]
+$ s3url s3://BUCKET/KEY [-d DURATION] [--profile PROFILE] [--upload UPLOAD]
 
 # Using options
-$ s3url -b BUCKET -k KEY [-d DURATION] [--profile PROFILE]
+$ s3url -b BUCKET -k KEY [-d DURATION] [--profile PROFILE] [--upload UPLOAD]
+```
+
+### Upload file together
+
+If there is no target object in the bucket yet, you can also upload file with `--upload` flag before getting Pre-signed URL. Following example shows that uploading `foo.key` to `s3://my-bucket/foo.key` and getting Pre-signed URL of `s3://my-bucket/foo.key` will be executed in series.
+
+```bash
+$ s3url s3://my-bucket/foo.key --upload foo.key
+uploaded: /path/to/foo.key
+https://my-bucket.s3-ap-northeast-1.amazonaws.com/foo.key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA***************************%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20160923T010227Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=****************************************************************
 ```
 
 ### Options
@@ -71,6 +75,7 @@ $ s3url -b BUCKET -k KEY [-d DURATION] [--profile PROFILE]
 |`-k`, `-key=KEY`|Object key|Required (if no URL is specified)||
 |`-d`, `-duration=DURATION`|Valid duration in minutes||5|
 |`--profile=PROFILE`|AWS profile name|||
+|`--upload=UPLOAD`|File to upload|||
 |`-h`, `-help`|Print command line usage|||
 
 ## Development

--- a/main.go
+++ b/main.go
@@ -17,6 +17,20 @@ const (
 	defaultDuration = 5
 )
 
+func getPresignedURL(svc *s3.S3, bucket, key string, duration int64) (string, error) {
+	req, _ := svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+
+	signedURL, err := req.Presign(time.Duration(duration) * time.Minute)
+	if err != nil {
+		return "", err
+	}
+
+	return signedURL, nil
+}
+
 func parseURL(s3URL string) (string, string, error) {
 	var bucket, key string
 
@@ -109,12 +123,8 @@ Options:
 	}
 
 	svc := s3.New(sess, &aws.Config{})
-	req, _ := svc.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
 
-	signedURL, err := req.Presign(time.Duration(duration) * time.Minute)
+	signedURL, err := getPresignedURL(svc, bucket, key, duration)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
## WHY

Sometimes target object does not exist, so that users have to upload file beforehand. However, there is no way to conclude entire process only with s3url. Users have to upload using Management Console or awscli.

## WHAT

Implement feature to upload file before getting Pre-signed URL. `--upload` flag is added to specify filename/filepath.