### PR TITLE
Accept virtual-hosted-style URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ go:
   - '1.7'
 before_script:
   - mkdir -p $GOPATH/bin
+install:
+  - make deps
 script:
-  - make
+  - make test
 before_deploy:
   - make cross-build
   - make dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - '1.7'
-before_script:
+before_install:
   - mkdir -p $GOPATH/bin
 install:
   - make deps

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ endif
 install:
 	go install $(LDFLAGS)
 
+.PHONY: test
+test:
+	go test -cover -v `glide novendor`
+
 .PHONY: update-deps
 update-deps: glide
 	glide update

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ export AWS_REGION=xx-yyyy-0
 Just type the command below and get Pre-signed URL on the screen.
 
 ```bash
-# https:// URL
+# https:// URL (both virtual-hosted-style and path-style)
+$ s3url https://BUCKET.s3-region.amazonaws.com/KEY [-d DURATION] [--profile PROFILE] [--upload UPLOAD]
 $ s3url https://s3-region.amazonaws.com/BUCKET/KEY [-d DURATION] [--profile PROFILE] [--upload UPLOAD]
 
 # s3:// URL

--- a/main.go
+++ b/main.go
@@ -3,11 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -17,59 +14,6 @@ import (
 const (
 	defaultDuration = 5
 )
-
-func getPresignedURL(svc *s3.S3, bucket, key string, duration int64) (string, error) {
-	req, _ := svc.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
-
-	signedURL, err := req.Presign(time.Duration(duration) * time.Minute)
-	if err != nil {
-		return "", err
-	}
-
-	return signedURL, nil
-}
-
-func parseURL(s3URL string) (string, string, error) {
-	var bucket, key string
-
-	u, err := url.Parse(s3URL)
-	if err != nil {
-		return "", "", fmt.Errorf("Invalid URL: %s.\n", s3URL)
-	}
-
-	if u.Scheme == "s3" { // s3://bucket/key
-		bucket = u.Host
-		key = strings.Replace(u.Path, "/", "", 1)
-	} else { // https://s3-ap-northeast-1.amazonaws.com/bucket/key
-		ss := strings.SplitN(u.Path, "/", 3)
-		bucket = ss[1]
-		key = ss[2]
-	}
-
-	return bucket, key, nil
-}
-
-func uploadToS3(svc *s3.S3, path, bucket, key string) error {
-	fp, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer fp.Close()
-
-	_, err = svc.PutObject(&s3.PutObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-		Body:   fp,
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func main() {
 	var (

--- a/s3.go
+++ b/s3.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func getPresignedURL(svc *s3.S3, bucket, key string, duration int64) (string, error) {
+	req, _ := svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+
+	signedURL, err := req.Presign(time.Duration(duration) * time.Minute)
+	if err != nil {
+		return "", err
+	}
+
+	return signedURL, nil
+}
+
+func parseURL(s3URL string) (string, string, error) {
+	var bucket, key string
+
+	u, err := url.Parse(s3URL)
+	if err != nil {
+		return "", "", fmt.Errorf("Invalid URL: %s.\n", s3URL)
+	}
+
+	if u.Scheme == "s3" { // s3://bucket/key
+		bucket = u.Host
+		key = strings.Replace(u.Path, "/", "", 1)
+	} else { // https://s3-ap-northeast-1.amazonaws.com/bucket/key
+		ss := strings.SplitN(u.Path, "/", 3)
+		bucket = ss[1]
+		key = ss[2]
+	}
+
+	return bucket, key, nil
+}
+
+func uploadToS3(svc *s3.S3, path, bucket, key string) error {
+	fp, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	_, err = svc.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   fp,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/s3_test.go
+++ b/s3_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	testdata := []struct {
+		url    string
+		bucket string
+		key    string
+	}{
+		{"https://s3-region.amazonaws.com/bucket/key.txt", "bucket", "key.txt"},
+		{"https://s3-region.amazonaws.com/bucket/dir/key.txt", "bucket", "dir/key.txt"},
+		{"s3://bucket/key.txt", "bucket", "key.txt"},
+		{"s3://bucket/dir/key.txt", "bucket", "dir/key.txt"},
+	}
+
+	for _, tt := range testdata {
+		bucket, key, err := parseURL(tt.url)
+		if err != nil {
+			t.Errorf("Error should not be raised. url: %s, error: %v", tt.url, err)
+		}
+
+		if bucket != tt.bucket {
+			t.Errorf("Bucket does not matched. expect: %s, actual: %s", tt.bucket, bucket)
+		}
+
+		if key != tt.key {
+			t.Errorf("Key does not matched. expect: %s, actual: %s", tt.key, key)
+		}
+	}
+}

--- a/s3_test.go
+++ b/s3_test.go
@@ -12,6 +12,10 @@ func TestParseURL(t *testing.T) {
 	}{
 		{"https://s3-region.amazonaws.com/bucket/key.txt", "bucket", "key.txt"},
 		{"https://s3-region.amazonaws.com/bucket/dir/key.txt", "bucket", "dir/key.txt"},
+		{"https://bucket.s3.amazonaws.com/key.txt", "bucket", "key.txt"},
+		{"https://bucket.s3.amazonaws.com/dir/key.txt", "bucket", "dir/key.txt"},
+		{"https://bucket.s3-region.amazonaws.com/key.txt", "bucket", "key.txt"},
+		{"https://bucket.s3-region.amazonaws.com/dir/key.txt", "bucket", "dir/key.txt"},
 		{"s3://bucket/key.txt", "bucket", "key.txt"},
 		{"s3://bucket/dir/key.txt", "bucket", "dir/key.txt"},
 	}


### PR DESCRIPTION
## WHAT

Accept virtual-hosted-style URL, e.g. `https://bucket.s3-ap-northeast-1.amazonaws.com/key.txt'.

To implement this feature. I added tests for `parseURL` function.

## REF

[Working with Amazon S3 Buckets - Amazon Simple Storage Service](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html)