### PR TITLE
Work with -b and -k correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,11 @@ Options:
 		sess = session.New()
 	}
 
+	if s3URL == "" && (bucket == "" || key == "") {
+		f.Usage()
+		os.Exit(1)
+	}
+
 	if s3URL != "" {
 		bucket, key, err = parseURL(s3URL)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -58,11 +58,6 @@ Options:
 		f.Parse(f.Args()[1:])
 	}
 
-	if s3URL == "" {
-		f.Usage()
-		os.Exit(1)
-	}
-
 	var sess *session.Session
 	var err error
 


### PR DESCRIPTION
## WHY

When giving bucket name and object key by flags, s3url shows usage and exits.

```bash
$ bin/s3url -b bucket -k object.txt
Usage of bin/s3url:
   bin/s3url https://s3-region.amazonaws.com/BUCKET/KEY [-d DURATION]
   bin/s3url s3://BUCKET/KEY [-d DURATION]
   bin/s3url -b BUCKET -k KEY [-d DURATION]

Options:
  -b, --bucket string    Bucket name
  -d, --duration int     Valid duration in minutes (default 5)
  -k, --key string       Object key
      --profile string   AWS profile name
  -v, --version          Print version
```

## WHAT

Work with `-b` and `-k` flags correctly.

```bash
$ bin/s3url -b bucket -k object.txt
https://bucket.s3-ap-northeast-1.amazonaws.com/object.txt?X-Amz-Algorithm=....
```