### PR TITLE
Reborn upload flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ Options:
 	f.Int64VarP(&duration, "duration", "d", defaultDuration, "Valid duration in minutes")
 	f.StringVarP(&key, "key", "k", "", "Object key")
 	f.StringVar(&profile, "profile", "", "AWS profile name")
+	f.StringVar(&upload, "upload", "", "File to upload")
 	f.BoolVarP(&version, "version", "v", false, "Print version")
 
 	f.Parse(os.Args[1:])


### PR DESCRIPTION
## WHY

Unfortunally `--upload` flag disappeared at https://github.com/dtan4/s3url/commit/a99ce2c2b62f7404304721b3c0250787ac0e844e .

## WHAT

Reborn `--upload` flag.