### PR TITLE
Update development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
-NAME := s3url
-VERSION := v0.3.1
+NAME     := s3url
+VERSION  := v0.3.1
 REVISION := $(shell git rev-parse --short HEAD)
 
+SRCS    := $(shell find . -type f -name '*.go')
 LDFLAGS := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$(REVISION)\""
 
 DIST_DIRS := find * -type d -exec
 
 .DEFAULT_GOAL := bin/$(NAME)
 
-bin/$(NAME): deps
+bin/$(NAME): $(SRCS)
 	go build $(LDFLAGS) -o bin/$(NAME)
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Precompiled binaries for Windows, OS X, Linux are available at [Releases](https:
 ```bash
 $ go get -d github.com/dtan4/s3url
 $ cd $GOPATH/src/github.com/dtan4/s3url
-$ make
+$ make deps
 $ make install
 ```
 
@@ -98,6 +98,7 @@ Retrieve this repository and build using `make`.
 ```bash
 $ go get -d github.com/dtan4/s3url
 $ cd $GOPATH/src/github.com/dtan4/s3url
+$ make deps
 $ make
 ```
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 87d1bc7c9e48ea08e563d6465ca5e5d6f242d6ca19acdce16b57c16cc59dace8
-updated: 2016-11-25T08:48:46.410307042+09:00
+hash: 421b8337497247472970e0f844dbdab56e480262d5c6e7ec27f8f410c28f9b3a
+updated: 2016-11-25T10:26:33.569898751+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 94673f7d41219ea3e94e4b1edc01315f14268f72
+  version: 4a6ff995f57ee4f8994db17ae83f01a9c9cc2274
   subpackages:
   - aws
   - aws/awserr

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/dtan4/s3url
 import:
 - package: github.com/aws/aws-sdk-go
-  version: v1.4.3
+  version: ^v1.5.10
   subpackages:
   - aws
   - aws/session


### PR DESCRIPTION
## WHAT

- Execute `make deps` separately. Now `make [bin/s3url]` does not execute `make deps` simutaneously.
- Update aws-sdk-go to v1.5.10.