### PR TITLE
Do not raise panic if invalid URL is given

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -37,6 +37,10 @@ func ParseURL(s3URL string) (string, string, error) {
 	} else {
 		if virtualHostRegexp.MatchString(u.Host) { // https://s3-ap-northeast-1.amazonaws.com/bucket/key
 			ss := strings.SplitN(u.Path, "/", 3)
+			if len(ss) < 3 {
+				return "", "", fmt.Errorf("Invalid path: %s", u.Path)
+			}
+
 			bucket = ss[1]
 			key = ss[2]
 		} else { // https://bucket.s3-ap-northeast-1.amazonaws.com/key

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -41,6 +41,10 @@ func ParseURL(s3URL string) (string, string, error) {
 			key = ss[2]
 		} else { // https://bucket.s3-ap-northeast-1.amazonaws.com/key
 			ss := strings.Split(u.Host, ".")
+			if len(ss) < 4 {
+				return "", "", fmt.Errorf("Invalid hostname: %s", u.Host)
+			}
+
 			bucket = strings.Join(ss[0:len(ss)-3], ".")
 			key = u.Path[1:]
 		}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -28,7 +28,7 @@ func ParseURL(s3URL string) (string, string, error) {
 
 	u, err := url.Parse(s3URL)
 	if err != nil {
-		return "", "", fmt.Errorf("Invalid URL: %s.\n", s3URL)
+		return "", "", fmt.Errorf("Invalid URL: %s", s3URL)
 	}
 
 	if u.Scheme == "s3" { // s3://bucket/key

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	virtualHostRegexp = regexp.MustCompile("^s3-[a-z0-9.]+\\.amazonaws\\.com$")
+	virtualHostRegexp = regexp.MustCompile(`^s3-[a-z0-9-]+\.amazonaws\.com$`)
 )
 
 // Client represents the wrapper of S3 API Client

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -38,7 +38,7 @@ func ParseURL(s3URL string) (string, string, error) {
 		if virtualHostRegexp.MatchString(u.Host) { // https://s3-ap-northeast-1.amazonaws.com/bucket/key
 			ss := strings.SplitN(u.Path, "/", 3)
 			if len(ss) < 3 {
-				return "", "", fmt.Errorf("Invalid path: %s", u.Path)
+				return "", "", fmt.Errorf("Invalid URL, path is invalid. url: %q, path: %q", s3URL, u.Path)
 			}
 
 			bucket = ss[1]
@@ -46,7 +46,7 @@ func ParseURL(s3URL string) (string, string, error) {
 		} else { // https://bucket.s3-ap-northeast-1.amazonaws.com/key
 			ss := strings.Split(u.Host, ".")
 			if len(ss) < 4 {
-				return "", "", fmt.Errorf("Invalid hostname: %s", u.Host)
+				return "", "", fmt.Errorf("Invalid URL, hostname is invalid. url: %q, hostname: %q", s3URL, u.Host)
 			}
 
 			bucket = strings.Join(ss[0:len(ss)-3], ".")

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -45,6 +45,21 @@ func TestParseURL(t *testing.T) {
 	}
 }
 
+func TestParseURL_invalid(t *testing.T) {
+	url := "foobarbaz"
+
+	_, _, err := ParseURL(url)
+	if err == nil {
+		t.Fatal("Error should be raised.")
+	}
+
+	expected := "Invalid hostname: "
+
+	if err.Error() != expected {
+		t.Fatalf("Error message does not match. expected: %s, actual: %s", expected, err.Error())
+	}
+}
+
 func TestNew(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -36,11 +36,11 @@ func TestParseURL(t *testing.T) {
 		}
 
 		if bucket != tc.bucket {
-			t.Errorf("Bucket does not matched. expect: %s, actual: %s", tc.bucket, bucket)
+			t.Errorf("Bucket does not match. expected: %s, actual: %s", tc.bucket, bucket)
 		}
 
 		if key != tc.key {
-			t.Errorf("Key does not matched. expect: %s, actual: %s", tc.key, key)
+			t.Errorf("Key does not match. expected: %s, actual: %s", tc.key, key)
 		}
 	}
 }

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -19,12 +19,12 @@ func TestParseURL(t *testing.T) {
 		bucket string
 		key    string
 	}{
-		{"https://s3-region.amazonaws.com/bucket/key.txt", "bucket", "key.txt"},
-		{"https://s3-region.amazonaws.com/bucket/dir/key.txt", "bucket", "dir/key.txt"},
+		{"https://s3-ap-northeast-1.amazonaws.com/bucket/key.txt", "bucket", "key.txt"},
+		{"https://s3-ap-northeast-1.amazonaws.com/bucket/dir/key.txt", "bucket", "dir/key.txt"},
 		{"https://bucket.s3.amazonaws.com/key.txt", "bucket", "key.txt"},
 		{"https://bucket.s3.amazonaws.com/dir/key.txt", "bucket", "dir/key.txt"},
-		{"https://bucket.s3-region.amazonaws.com/key.txt", "bucket", "key.txt"},
-		{"https://bucket.s3-region.amazonaws.com/dir/key.txt", "bucket", "dir/key.txt"},
+		{"https://bucket.s3-ap-northeast-1.amazonaws.com/key.txt", "bucket", "key.txt"},
+		{"https://bucket.s3-ap-northeast-1.amazonaws.com/dir/key.txt", "bucket", "dir/key.txt"},
 		{"s3://bucket/key.txt", "bucket", "key.txt"},
 		{"s3://bucket/dir/key.txt", "bucket", "dir/key.txt"},
 	}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -46,17 +46,29 @@ func TestParseURL(t *testing.T) {
 }
 
 func TestParseURL_invalid(t *testing.T) {
-	url := "foobarbaz"
-
-	_, _, err := ParseURL(url)
-	if err == nil {
-		t.Fatal("Error should be raised.")
+	testcases := []struct {
+		url    string
+		errMsg string
+	}{
+		{
+			url:    "foobarobaz",
+			errMsg: "Invalid hostname: ",
+		},
+		{
+			url:    "https://s3-ap-northeast-1.amazonaws.com/bucket",
+			errMsg: "Invalid path: /bucket",
+		},
 	}
 
-	expected := "Invalid hostname: "
+	for _, tc := range testcases {
+		_, _, err := ParseURL(tc.url)
+		if err == nil {
+			t.Fatal("Error should be raised.")
+		}
 
-	if err.Error() != expected {
-		t.Fatalf("Error message does not match. expected: %s, actual: %s", expected, err.Error())
+		if err.Error() != tc.errMsg {
+			t.Fatalf("Error message does not match. expected: %s, actual: %s", tc.errMsg, err.Error())
+		}
 	}
 }
 

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -51,23 +51,23 @@ func TestParseURL_invalid(t *testing.T) {
 		errMsg string
 	}{
 		{
-			url:    "foobarobaz",
-			errMsg: "Invalid hostname: ",
+			url:    "foobarbaz",
+			errMsg: "Invalid URL, hostname is invalid. url: \"foobarbaz\", hostname: \"\"",
 		},
 		{
 			url:    "https://s3-ap-northeast-1.amazonaws.com/bucket",
-			errMsg: "Invalid path: /bucket",
+			errMsg: "Invalid URL, path is invalid. url: \"https://s3-ap-northeast-1.amazonaws.com/bucket\", path: \"/bucket\"",
 		},
 	}
 
 	for _, tc := range testcases {
 		_, _, err := ParseURL(tc.url)
 		if err == nil {
-			t.Fatal("Error should be raised.")
+			t.Error("Error should be raised.")
 		}
 
 		if err.Error() != tc.errMsg {
-			t.Fatalf("Error message does not match. expected: %s, actual: %s", tc.errMsg, err.Error())
+			t.Errorf("Error message does not match. expected: %s, actual: %s", tc.errMsg, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
## WHY

If invalid URL is given, current s3url raises panic.

```bash
$ bin/s3url hoge
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
panic(0x3cc7c0, 0xc420014170)
        /usr/local/Cellar/go/1.7.4/libexec/src/runtime/panic.go:500 +0x1a1
github.com/dtan4/s3url/s3.ParseURL(0x7fff5fbfeb32, 0x4, 0x0, 0xc4200826e0, 0x0, 0x0, 0x43d500, 0x43d04a)
        /Users/dtan4/src/github.com/dtan4/s3url/s3/s3.go:44 +0x21d
main.main()
        /Users/dtan4/src/github.com/dtan4/s3url/main.go:85 +0xeaa
```

## WHAT

Add guard and error handling for invalid URL.