### PR TITLE
Remove ~/.aws/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ $ make install
 
 ## Usage
 
-You need to set AWS credentials beforehand, or you can also use [named profile](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles) written in `~/.aws/credentials` and `~/.aws/config`.
+You need to set AWS credentials beforehand, or you can also use [named profile](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles) written in `~/.aws/credentials`.
 
 ```bash
 export AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXXX
 export AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# or configure them in ~/.aws/credentials
+
 export AWS_REGION=xx-yyyy-0
 ```
 


### PR DESCRIPTION
According to [the documentation](https://github.com/aws/aws-sdk-go#aws-shared-config-file-awsconfig), `~/.aws/config` will never be read unless `AWS_SDK_LOAD_CONFIG`.