### PR TITLE
Upload local file using stream

### DIFF
--- a/_testdata/test.txt
+++ b/_testdata/test.txt
@@ -1,0 +1,1 @@
+This is a test file.

--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"bytes"
+	"io"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,11 +38,11 @@ func (c *Client) GetPresignedURL(bucket, key string, duration int64) (string, er
 }
 
 // UploadToS3 uploads local file to the specified S3 location
-func (c *Client) UploadToS3(bucket, key string, body []byte) error {
+func (c *Client) UploadToS3(bucket, key string, reader io.ReadSeeker) error {
 	_, err := c.api.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
-		Body:   bytes.NewReader(body),
+		Body:   reader,
 	})
 	if err != nil {
 		return errors.Wrap(err, "cannot upload file to S3")

--- a/aws/s3/s3_test.go
+++ b/aws/s3/s3_test.go
@@ -1,6 +1,8 @@
 package s3
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -96,5 +98,27 @@ func TestUploadToS3(t *testing.T) {
 
 	if err := client.UploadToS3(bucket, key, f); err != nil {
 		t.Fatalf("Error should not be raised. error: %s", err)
+	}
+}
+
+func BenchmarkReadFileEntirely(b *testing.B) {
+	testfile := filepath.Join("..", "..", "_testdata", "test.txt")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		body, _ := ioutil.ReadFile(testfile)
+		r := bytes.NewReader(body)
+		_, _ = ioutil.ReadAll(r)
+	}
+}
+
+func BenchmarkReadFileStream(b *testing.B) {
+	testfile := filepath.Join("..", "..", "_testdata", "test.txt")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		f, _ := os.Open(testfile)
+		_, _ = ioutil.ReadAll(f)
+		f.Close()
 	}
 }


### PR DESCRIPTION
This change can reduce memory consumption.

Current implementation reads entire target file at first. If the file is large, memory consumption will be also large.
New implementation reads file line by line. This can reduce memory consumption even however the file is large.