### PR TITLE
Add new workflow to run `go mod tidy` automatically

### DIFF
--- a/.github/workflows/go-mod-tidy.yaml
+++ b/.github/workflows/go-mod-tidy.yaml
@@ -1,0 +1,41 @@
+name: go mod tidy
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/go-mod-tidy.yaml"
+
+jobs:
+  go-mod-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12
+      - name: go mod tidy
+        run: |
+          go mod tidy
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "go mod tidy"
+          title: "Run `go mod tidy`"
+          body: |
+            ## WHAT
+            Run `go mod tidy`
+
+            This pull request was created by [create-pull-request](https://github.com/peter-evans/create-pull-request).
+
+            ## WHY
+
+            Current `go.mod` and `go.sum` don't match the source code.
+          branch-name: go-mod-tidy
+          branch-suffix: timestamp

--- a/.github/workflows/go-mod-tidy.yaml
+++ b/.github/workflows/go-mod-tidy.yaml
@@ -37,5 +37,5 @@ jobs:
             ## WHY
 
             Current `go.mod` and `go.sum` don't match the source code.
-          branch-name: go-mod-tidy
+          branch: go-mod-tidy
           branch-suffix: timestamp


### PR DESCRIPTION
## WHAT

Add new workflow to run `go mod tidy` automatically

This action runs `go mod tidy` when new dependencies added or updated in `go.mod` or `go.sum` (or this action file is updated), then create a new Pull Request for it if it contains diff, which means master `go.mod` and `go.sum` don't match the current source code.

This workflow uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) action.

## WHY

Sometimes we forgot to execute this by hand. In addition to this, Dependabot doesn't execute `go mod tidy` for now.