### PR TITLE
Use Personal token to create Pull Request from GitHub Actions

### DIFF
--- a/.github/workflows/go-mod-tidy.yaml
+++ b/.github/workflows/go-mod-tidy.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
           commit-message: "go mod tidy"
           title: "Run `go mod tidy`"
           body: |


### PR DESCRIPTION
## WHAT

Use [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) to create Pull Request from GitHub Actions instead of [GitHub Action's token](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token).

![image](https://user-images.githubusercontent.com/680124/70866024-bbdc5500-1fa7-11ea-8c06-b76c65868798.png)


## WHY

REF: 

- [PRs created don't trigger other actions · Issue #48 · peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/issues/48)
- https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#example-using-more-than-one-event

Triggering any actions from Pull Request created by Action's token is unavailable because of the safety reasons. Due to this, `go mod tidy` -> create a Pull Request -> run tests in GitHub Actions doesn't work.