### PR TITLE
Use GoReleaser GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,8 @@ on:
       - "v*.*.*"
 
 jobs:
-  release:
-    runs-on: ubuntu-18.04
+  goreleaser:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -14,13 +14,10 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.12
-      - name: Build binaries
-        run: GO111MODULE=on make cross-build
-      - name: Build artifacts
-        run: make dist
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
         with:
-          files: "dist/*.tar.gz,dist/*.zip"
+          version: latest
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,4 +20,6 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # To upload Homebrew recipe to dtan4/homebrew-tools, we need a personal token
+          # instead of Action's temporary token
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,3 +49,5 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+    - Merge pull request
+    - Merge branch

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ archives:
   format_overrides:
   - goos: windows
     format: zip
+release:
+  prerelease: auto
 brews:
 - github:
     owner: dtan4


### PR DESCRIPTION
Use [GoReleaser GitHub Action](https://github.com/goreleaser/goreleaser-action) to release tagged binaries to GitHub automatically