### PR TITLE
Use Go 1.15 in GitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.15
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.15
       - name: Run tests
         run: GO111MODULE=on make ci-test
       - name: Send test coverage to Codecov


### PR DESCRIPTION
aws-sdk-go-v2 requires Go 1.15 or above.

[Migrating to the AWS SDK for Go V2 | AWS SDK for Go V2](https://aws.github.io/aws-sdk-go-v2/docs/migrating/#minimum-go-version)

> The AWS SDK for Go V2 requires a minimum version of Go 1.15. Migration from AWS SDK for Go to AWS SDK for Go V2 might require you to upgrade your application by one or more Go versions. 