### PR TITLE
Remove CODECOV_TOKEN

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,5 +20,3 @@ jobs:
         run: GO111MODULE=on make ci-test
       - name: Send test coverage to Codecov
         uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This token is not required for public repositories